### PR TITLE
Fix url in display templates, so that it uses absolute urls.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,10 +4,13 @@ Changelog
 1.0.6 (unreleased)
 ------------------
 
+* Fix url in display templates, so that it uses absolute urls.
+  [phgross]
+
 * pep8
   [joka]
 
-* Fix term title genration to use the brain id if there is not brain title 
+* Fix term title genration to use the brain id if there is not brain title
   [joka]
 
 * Added Italian translation.

--- a/plone/formwidget/contenttree/display_multiple.pt
+++ b/plone/formwidget/contenttree/display_multiple.pt
@@ -1,4 +1,8 @@
 <span id="" class=""
+      tal:define="url_tool context/@@plone_tools/url;
+                  portal_url url_tool/portal_url;
+                  portal_path url_tool/getPortalPath"
+
       tal:attributes="id view/id;
                       class view/klass;
                       style view/style;
@@ -17,7 +21,7 @@
         >
     <div tal:repeat="term view/terms">
         <a tal:content="term/title"
-           tal:attributes="href term/token"
+           tal:attributes="href python: term.token.replace(portal_path, portal_url, 1)"
            tal:condition="python:not(term.token.startswith('#error-'))"
            />
     </div>

--- a/plone/formwidget/contenttree/display_single.pt
+++ b/plone/formwidget/contenttree/display_single.pt
@@ -1,4 +1,8 @@
 <span id="" class=""
+      tal:define="url_tool context/@@plone_tools/url;
+                  portal_url url_tool/portal_url;
+                  portal_path url_tool/getPortalPath"
+
       tal:attributes="id view/id;
                       class view/klass;
                       style view/style;
@@ -17,7 +21,7 @@
         >
     <div tal:repeat="term view/terms">
         <a tal:content="term/title"
-           tal:attributes="href term/token"
+           tal:attributes="href python: term.token.replace(portal_path, portal_url, 1)"
            tal:condition="python:not(term.token.startswith('#error-'))"
            />
     </div>


### PR DESCRIPTION
I've fixed the link generation in the the display templates. It generates now an absolute url (including the portal_url), instead of using only the token(path) as href, which was a relative path.

cheers philippe
