### PR TITLE
Performance improvements

### DIFF
--- a/plone/formwidget/contenttree/configure.zcml
+++ b/plone/formwidget/contenttree/configure.zcml
@@ -20,6 +20,14 @@
         class=".widget.Fetch"
         />
 
+   <browser:page
+        name="contenttree-fetch-init"
+        for=".interfaces.IContentTreeWidget"
+        permission="zope.Public"
+        class=".widget.FetchInit"
+        template="fragment_init.pt"
+        />
+
     <browser:resourceDirectory
         name="plone.formwidget.contenttree"
         directory="jquery-contenttree"

--- a/plone/formwidget/contenttree/fragment_init.pt
+++ b/plone/formwidget/contenttree/fragment_init.pt
@@ -1,0 +1,3 @@
+<ul class="navTree navTreeLevel0">
+        <li tal:replace="structure view/render_tree" />
+</ul>

--- a/plone/formwidget/contenttree/input.pt
+++ b/plone/formwidget/contenttree/input.pt
@@ -1,26 +1,24 @@
 <i18n:domain i18n:domain="plone.formwidget.contenttree">
-	<div tal:attributes="id string:${view/id}-autocomplete">
-	    <div tal:attributes="id string:${view/id}-input-fields" class="autocompleteInputWidget"
-	         tal:content="structure view/renderQueryWidget" />
-	    <tal:block replace="structure view/subform/render" />
-	</div>
-	<div class="contenttreeWindow"
-	    tal:attributes="id string:${view/id}-contenttree-window">
+  <div tal:attributes="id string:${view/id}-autocomplete">
+    <div tal:attributes="id string:${view/id}-input-fields" class="autocompleteInputWidget"
+         tal:content="structure view/renderQueryWidget" />
+    <tal:block replace="structure view/subform/render" />
+  </div>
+  <div class="contenttreeWindow"
+       tal:attributes="id string:${view/id}-contenttree-window">
 	<div class="contenttreeWindowHeader">
-	<h2 i18n:translate="heading_contenttree_browse">Browse for items</h2>
-    <em tal:condition="view/multi_select"
-        i18n:translate="heading_contenttree_help">Press Ctrl to select multiple items.
-    </em>
+      <h2 i18n:translate="heading_contenttree_browse">Browse for items</h2>
+      <em tal:condition="view/multi_select"
+          i18n:translate="heading_contenttree_help">Press Ctrl to select multiple items.
+      </em>
 	</div>
-	<div class="contenttreeWidget"
-	    tal:attributes="id string:${view/id}-contenttree">
-	    <ul class="navTree navTreeLevel0">
-	        <li tal:replace="structure view/render_tree" />
-	    </ul>
+	<div class="contenttreeWidget contenttreeWidgetAjax"
+         tal:attributes="id string:${view/id}-contenttree">
+      <p>hest</p>
 	</div>
 	<div class="contenttreeWindowActions">
-	<input class="context contentTreeAdd" type="button" i18n:attributes="value label_contenttree_add" value="Add"/> <input class="standalone contentTreeCancel" i18n:attributes="value label_contenttree_cancel" type="button" value="Cancel"/>
+      <input class="context contentTreeAdd" type="button" i18n:attributes="value label_contenttree_add" value="Add"/> <input class="standalone contentTreeCancel" i18n:attributes="value label_contenttree_cancel" type="button" value="Cancel"/>
 	</div>
-	</div>
-	<script type="text/javascript" tal:content="structure view/js"></script>
+  </div>
+  <script type="text/javascript" tal:content="structure view/js"></script>
 </i18n:domain>


### PR DESCRIPTION
Due to a many referencefields on one form, the HTML output became pretty big and took a long time to generate on one of our sites. This was caused because the navigation structure was big, and it has to be generated many times. Our branch uses ajax to fetch the initial navigation structure, which solves our performance issue. The size of the generated HTML document has been reduced significantly, and the edit forms loads much faster now.
