### PR TITLE
Added check in tree generation if it allready exists 

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.0.7 (unreleased)
 ------------------
 
+* Added check in tree generation if it allready exists (reopening the contenttree window).
+  [phgross]
+
 1.0.6 (2012-09-28)
 ------------------
 

--- a/plone/formwidget/contenttree/jquery-contenttree/contenttree.js
+++ b/plone/formwidget/contenttree/jquery-contenttree/contenttree.js
@@ -105,10 +105,12 @@ if(jQuery) (function($){
                 $(t).find('li.selectable a').bind(o.selectEvent, handleSelectEvent);
             }
 
-            $(this).each(function() {
+            if ($(this).children('ul.navTree').length <= 0) {
+              $(this).each(function() {
+                  loadTree(this, o.rootUrl, 0);
+              });
+            }
 
-                loadTree(this, o.rootUrl, 0);
-            });
         }
     });
 


### PR DESCRIPTION
The content tree widget has a small bug where, when you close or cancel and reopen the Contenttree Window, it reopens with the previous content already loaded, AND loads the content again with an AJAX load.

This leads to the content multiplying every time you reopen the content tree window.

I've fixed this bug with a small check if the navtree element already exists. This solution has the advantage over removing the navtree on cancel that the tree is already expanded like before.
