### PR TITLE
Make sure to display relevant content, even if it is not present in the navigation

### DIFF
--- a/plone/formwidget/contenttree/source.py
+++ b/plone/formwidget/contenttree/source.py
@@ -83,6 +83,14 @@ class PathSource(object):
 
         query.update(navigation_tree_query)
 
+        # If we filter by portal_type, make sure those portal types are present
+        # in the query, even if they would not appear in the navigation
+        if ('portal_type' in query
+                and 'portal_type' in selectable_filter.criteria):
+            for ptype in selectable_filter.criteria['portal_type']:
+                if ptype not in query['portal_type']:
+                    query['portal_type'].append(ptype)
+
         self.navigation_tree_query = query
         self.selectable_filter = selectable_filter
 


### PR DESCRIPTION
If a certain portal type is globally excluded from the navigation (e.g. via @@navigation-controlpanel), we need to make sure that items of this type still get displayed in the folder-tree if there is an explicit filter for them.

_Simple use case for explanation_: A Choice field with `source=ObjPathSourceBinder(portal_type='Image')`, and Images being excluded from the navigation.

Since the query for the folder tree is built using INavigationQueryBuilder, images are not displayed, even though we explicitly want to filter for them.

This pull request should fix that.
