### PR TITLE
Ticket #13465 plone.formwidget.contenttree does not show all contents

### DIFF
--- a/plone/formwidget/contenttree/navtree.py
+++ b/plone/formwidget/contenttree/navtree.py
@@ -52,6 +52,9 @@ class QueryBuilder(object):
         else:
             query['path'] = {'query': currentPath, 'navtree': 1}
 
+        # Only list the applicable types
+        query['portal_type'] = utils.typesToList(context)
+
         # Apply the desired sort
         sortAttribute = navtree_properties.getProperty('sortAttribute', None)
         if sortAttribute is not None:

--- a/plone/formwidget/contenttree/widget.py
+++ b/plone/formwidget/contenttree/widget.py
@@ -79,6 +79,10 @@ class Fetch(BrowserView):
         level = self.request.form.get('rel', 0)
 
         navtree_query = source.navigation_tree_query.copy()
+
+        if widget.show_all_content_types and 'portal_type' in navtree_query:
+            del navtree_query['portal_type']
+
         if directory is not None:
             navtree_query['path'] = {'depth': 1, 'query': directory}
 
@@ -133,6 +137,10 @@ class ContentTreeBase(Explicit):
     # By default, only show 'interesting' nodes, that is: nodes that
     # are selectable or that are folders.
     show_all_nodes = False
+
+    # By default, show all content types, even those not allowed in
+    # the navigation
+    show_all_content_types = True
 
     def getTermByBrain(self, brain):
         return self.bound_source.getTermByBrain(brain)


### PR DESCRIPTION
Make sure plone.formwidget.contenttree widget shows all contents and not only content type is allowed by the site navigation settings.
See https://dev.plone.org/ticket/13465
