### PR TITLE
work around bizarro Diazo encoding bug

### DIFF
--- a/plone/formwidget/contenttree/widget.py
+++ b/plone/formwidget/contenttree/widget.py
@@ -176,7 +176,7 @@ class ContentTreeBase(Explicit):
         return """\
 
                 $('#%(id)s-widgets-query').each(function() {
-                    if($(this).siblings('input.searchButton').length > 0) { return; }
+                    if($(this).siblings('input.searchButton').length != 0) { return; }
                     $(document.createElement('input'))
                         .attr({
                             'type': 'button',


### PR DESCRIPTION
I've run into a bug
- Where ">" gets encoded to "&amp;gt;" unless ?diazo.off=1
- for javascript loaded from this widget
- but not for the same javascript inserted directly in a template

After hunting for hours for a solution this is the best I can come up with.

Since the fix is a simple two-char I hope you'll merge this pull and relieve me from having to maintain a fork.
