### PR TITLE
Slice search results in `PathSource` object to limit the search results correctly.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,8 +10,9 @@ New:
 
 Fixes:
 
-- *add item here*
-
+- Slice search results in `PathSource` object to limit the search results correctly.
+  http://docs.plone.org/develop/plone/searching_and_indexing/query.html#sorting-and-limiting-the-number-of-results
+  [elioschmutz]
 
 1.0.13 (2016-02-09)
 -------------------
@@ -26,7 +27,7 @@ New:
 -------------------
 
 - Remove unnecessary test setup.
-  [timo] 
+  [timo]
 
 - Fix HTML entities in browse button title
   [gaudenz]

--- a/plone/formwidget/contenttree/source.py
+++ b/plone/formwidget/contenttree/source.py
@@ -66,7 +66,7 @@ class PathSource(object):
 
     def __init__(self, context, selectable_filter, navigation_tree_query=None, default=None, defaultFactory=None):
         self.context = context
-        
+
         nav_root = getNavigationRootObject(context, None)
         query_builder = getMultiAdapter((nav_root, self),
                                         INavigationQueryBuilder)
@@ -153,12 +153,10 @@ class PathSource(object):
             catalog_query['sort_limit'] = limit
 
         try:
-            results = (self.getTermByBrain(brain, real_value=False)
-                       for brain in self.catalog(**catalog_query))
+            for brain in self.catalog(**catalog_query)[:limit]:
+                yield self.getTermByBrain(brain, real_value=False)
         except ParseError:
-            return []
-
-        return results
+            pass
 
     def isBrainSelectable(self, brain):
         if brain is None:


### PR DESCRIPTION
Slice search results in `PathSource` object to limit the search results correctly according to the plonedoc:
http://docs.plone.org/develop/plone/searching_and_indexing/query.html#sorting-and-limiting-the-number-of-results.

The Catalog can return more than the given amount of objects defined in the `sort_limit` parameter. If the default plone catalog will return more objects, it will return brains. Some catalog implementations (i.e. `colletcitve.solr`) will fill this additional slots with `None`. 

If we don't slice the search results as described in the plone docs, we will ran into an Attribute error in https://github.com/plone/plone.formwidget.contenttree/blob/master/plone/formwidget/contenttree/source.py#L170 if the catalog returns more objects than defined in the `limit` parameter.

@tisto @mauritsvanrees could you review my branch and merge it? Thanks a lot!