### PR TITLE
Fixed handling of empty references on dexterity types 

### DIFF
--- a/plone/formwidget/contenttree/source.py
+++ b/plone/formwidget/contenttree/source.py
@@ -198,14 +198,17 @@ class PathSource(object):
     # brain. These will get hidden in the display templates
     def _placeholderTerm(self, value):
         return SimpleTerm(str(value),
-                          token='#error-missing-' + value,
-                          title=u"Hidden or missing item '%s'" % value)
+                          token='#error-missing-' + str(value),
+                          title=u"Hidden or missing item '%s'" % str(value))
 
 
 class ObjPathSource(PathSource):
 
     def _getBrainByValue(self, value):
-        return self._getBrainByToken('/'.join(value.getPhysicalPath()))
+        try:
+            return self._getBrainByToken('/'.join(value.getPhysicalPath()))
+        except AttributeError:
+            return None
 
     def getTermByBrain(self, brain, real_value=True):
         if real_value:


### PR DESCRIPTION
Hi there,

I have found that `plone.formwidget.contenttree` does not handle empty `Related items` well. All my references in a page where broken during development and this then blocked the `edit_form` with an error.

**How to reproduce:**
- Create a dexterit content type and add the `Related items`-behavior
- Add a reference (Related Item) to an instance of your content type and save
- Delete the reference in the ZODB or itself. (this is guesswork, mine went just off)
- Try to edit the instance of your content type -> ERROR
