### PR TITLE
Speedup listing content in fetch-contenttree

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,17 +4,13 @@ Changelog
 1.0.16 (unreleased)
 -------------------
 
-Breaking changes:
+Fixes:
 
-- *add item here*
-
-New features:
-
-- *add item here*
-
-Bug fixes:
-
-- *add item here*
+- If the widget is loaded without a content filter to limit the content listing,
+  skip retrieving all index data for the brain from the catalog in
+  isBrainSelectable. This considerably speeds up listing folders with many items
+  that have large (SearchableText) indexes.
+  [fredvd, mauritsvanrees]
 
 
 1.0.15 (2016-08-08)

--- a/plone/formwidget/contenttree/source.py
+++ b/plone/formwidget/contenttree/source.py
@@ -161,6 +161,12 @@ class PathSource(object):
     def isBrainSelectable(self, brain):
         if brain is None:
             return False
+        if not getattr(self.selectable_filter, 'criteria', True):
+            # Short circuits expensive index retrieval for large objects.
+            # Without filter criteria selectable_filter will always return true.
+            # For custom implementations of CustomFilter, continue retrieving
+            # indexes.
+            return True
         index_data = self.catalog.getIndexDataForRID(brain.getRID())
         return self.selectable_filter(brain, index_data)
 


### PR DESCRIPTION
if no filter criteria are present. This boosts for example the related
items widget in Plone 4 + plone.app.contenttypes for large folders that
have large (indexed) content.